### PR TITLE
Fix duplicate admin site

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -5,9 +5,7 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Group, Permission
-from django.urls import path
-from django.utils.translation import gettext_lazy as _
-from django.views.i18n import set_language
+from myproject.admin import custom_admin_site
 
 User = get_user_model()
 
@@ -15,31 +13,7 @@ User = get_user_model()
 # Pielāgots admin site
 # ============================
 
-class CustomAdminSiteWithLanguageSwitcher(admin.AdminSite):
-    site_header = _("Management System Tools")
-    site_title = _("Administration")
-    index_title = _("System Management")
-
-    def get_urls(self):
-        """Adds a language switching URL to the admin panel."""
-        return [path("set_language/", set_language, name="set_language"), *super().get_urls()]
-
-    def get_app_list(self, request, app_label=None):
-        """Customizes app ordering in the admin panel."""
-        app_list = super().get_app_list(request, app_label)
-        custom_order = {
-            "quality_docs": _("Documentation"),
-            "methods": _("Method Management"),
-            "equipment": _("Equipment Registry"),
-            "staff": _("Personnel Management"),
-            "audits": _("Audits"),
-            "risks": _("Risk Management"),
-            "kpi": _("KPI Management"),
-        }
-        return sorted(app_list, key=lambda x: custom_order.get(x["app_label"], x["name"]))
-
-
-custom_admin_site = CustomAdminSiteWithLanguageSwitcher(name="custom_admin")
+# Use the project's custom admin site for all registrations
 
 # 👥 User Management
 @admin.register(User, site=custom_admin_site)

--- a/accounts/admin_registry.py
+++ b/accounts/admin_registry.py
@@ -1,4 +1,4 @@
-from accounts.custom_admin import custom_admin_site
+from myproject.admin import custom_admin_site
 
 
 def get_standard_admin():

--- a/methods/admin/__init__.py
+++ b/methods/admin/__init__.py
@@ -2,7 +2,7 @@
 from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered
 
-from accounts.custom_admin import custom_admin_site
+from myproject.admin import custom_admin_site
 from methods.models import MetozuRegistrs
 
 

--- a/myproject/urls.py
+++ b/myproject/urls.py
@@ -4,7 +4,7 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from django.views.generic import TemplateView, RedirectView
-from accounts.admin import custom_admin_site  # ✅ JAUNA RINDA
+from myproject.admin import custom_admin_site
 from django.conf.urls.i18n import i18n_patterns
 
 urlpatterns = [

--- a/standards/admin.py
+++ b/standards/admin.py
@@ -11,7 +11,7 @@ from .models.standards import (
     StandardRequirement,
     StandardComplianceStatus
 )
-from accounts.admin import custom_admin_site
+from myproject.admin import custom_admin_site
 
 @admin.register(Standard, site=custom_admin_site)
 class StandardAdmin(admin.ModelAdmin):

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -5,6 +5,22 @@
 {% block title %}{% trans "Login" %}{% endblock %}
 
 {% block content %}
+<div class="language-selector text-end mb-3">
+    <form action="{% url 'set_language' %}" method="post" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <select name="language" onchange="this.form.submit()" class="form-select form-select-sm w-auto d-inline">
+            {% get_available_languages as LANGUAGES %}
+            {% get_language_info_list for LANGUAGES as languages %}
+            {% get_current_language as LANGUAGE_CODE %}
+            {% for language in languages %}
+            <option value="{{ language.code }}" {% if language.code == LANGUAGE_CODE %}selected{% endif %}>
+                {{ language.name_local|title }}
+            </option>
+            {% endfor %}
+        </select>
+    </form>
+</div>
 <div class="row justify-content-center">
     <div class="col-md-6">
         <div class="card mt-5">


### PR DESCRIPTION
### **User description**
## Summary
- reuse the custom admin site from `myproject.admin`
- update imports in `accounts` and `standards` admin modules
- update URL configuration to use the unified admin site
- add language switcher to the login page
- update remaining admin imports to use the unified admin site

## Testing
- `ruff check .` *(fails: Found 1295 errors)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684006276440832c93a5570a869e4094


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Centralize use of `custom_admin_site` from `myproject.admin`
  - Update all admin imports to use unified admin site
  - Remove redundant custom admin site implementation in `accounts`

- Add language switcher to login page

- Update URL configuration to use unified admin site


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.py</strong><dd><code>Remove local admin site, use centralized custom admin site</code></dd></summary>
<hr>

accounts/admin.py

<li>Remove local custom admin site implementation<br> <li> Import and use <code>custom_admin_site</code> from <code>myproject.admin</code><br> <li> Register User admin with centralized admin site


</details>


  </td>
  <td><a href="https://github.com/Viesturs71/quality_tools_v3/pull/7/files#diff-b51de91e6013e96d4f9715ad9486544509b319e4fdba3ae8248f9c955a38062a">+2/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin_registry.py</strong><dd><code>Use unified custom admin site import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

accounts/admin_registry.py

- Update import to use `custom_admin_site` from `myproject.admin`


</details>


  </td>
  <td><a href="https://github.com/Viesturs71/quality_tools_v3/pull/7/files#diff-63b44c5116bdc6d2f298230b36cf74c257b032190ed198ffbc9e2693cf2eeb1f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Use unified custom admin site import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

methods/admin/__init__.py

- Update import to use `custom_admin_site` from `myproject.admin`


</details>


  </td>
  <td><a href="https://github.com/Viesturs71/quality_tools_v3/pull/7/files#diff-e0a96f8ec8e1edf0bb52d8e2107ea59de1459e764731db5464c7f60e30084b58">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>urls.py</strong><dd><code>Use centralized custom admin site in URL config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

myproject/urls.py

- Update admin site import to use `myproject.admin.custom_admin_site`


</details>


  </td>
  <td><a href="https://github.com/Viesturs71/quality_tools_v3/pull/7/files#diff-52ed90ee526269401ce569672daf2d260402bf813ba460b8b83916b8bbaa0a3a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin.py</strong><dd><code>Use unified custom admin site for standards admin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

standards/admin.py

<li>Update import to use <code>custom_admin_site</code> from <code>myproject.admin</code><br> <li> Register Standard admin with unified admin site


</details>


  </td>
  <td><a href="https://github.com/Viesturs71/quality_tools_v3/pull/7/files#diff-8512ebce3d1d0c31fb82881576406f8e2d922815ad80ba74d4c3f1c0820de12f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>login.html</strong><dd><code>Add language switcher to login page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/registration/login.html

<li>Add language selector dropdown to login page<br> <li> Submit language change via POST to <code>set_language</code>


</details>


  </td>
  <td><a href="https://github.com/Viesturs71/quality_tools_v3/pull/7/files#diff-69609650c7250a0e58c62abba2c6c1cd432ae88c4739091ccd9f8c3395f4add1">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>